### PR TITLE
edx notes api Dockerfile Python 3.12 upgrade

### DIFF
--- a/.github/workflows/push-edx-notes-api-image.yaml
+++ b/.github/workflows/push-edx-notes-api-image.yaml
@@ -8,6 +8,8 @@ on:
 
   schedule:
     - cron: "0 4 * * 1-5"  # UTC Time
+  
+  pull_request:
 
 jobs:
   build-and-push-image:
@@ -41,7 +43,7 @@ jobs:
           file: ./dockerfiles/edx-notes-api.Dockerfile
           push: true
           target: dev
-          tags: edxops/edx-notes-api-dev:${{ steps.get-tag-name.outputs.result }}
+          tags: edxops/edx-notes-api-dev:test
           platforms: linux/amd64,linux/arm64
 
       - name: Send failure notification

--- a/.github/workflows/push-edx-notes-api-image.yaml
+++ b/.github/workflows/push-edx-notes-api-image.yaml
@@ -8,8 +8,6 @@ on:
 
   schedule:
     - cron: "0 4 * * 1-5"  # UTC Time
-  
-  pull_request:
 
 jobs:
   build-and-push-image:
@@ -43,7 +41,7 @@ jobs:
           file: ./dockerfiles/edx-notes-api.Dockerfile
           push: true
           target: dev
-          tags: edxops/edx-notes-api-dev:test
+          tags: edxops/edx-notes-api-dev:${{ steps.get-tag-name.outputs.result }}
           platforms: linux/amd64,linux/arm64
 
       - name: Send failure notification

--- a/dockerfiles/edx-notes-api.Dockerfile
+++ b/dockerfiles/edx-notes-api.Dockerfile
@@ -23,25 +23,26 @@ ENV TZ=UTC
 ENV TERM=xterm-256color
 ENV DEBIAN_FRONTEND=noninteractive
 
+# software-properties-common is needed to setup Python 3.12 env
 RUN apt-get update && \
-    apt-get install -y software-properties-common && \
-    apt-add-repository -y ppa:deadsnakes/ppa && \
-    apt-get update && apt-get upgrade -qy && \
-    apt-get install \
+  apt-get install -y software-properties-common && \
+  apt-add-repository -y ppa:deadsnakes/ppa
+
+RUN apt-get update && apt-get -qy install --no-install-recommends \
     build-essential \
     language-pack-en \
     locales \
-    git \
-    curl \
     pkg-config \
     libssl-dev \
     libffi-dev \
     libsqlite3-dev \
     libmysqlclient-dev \
+    git \
+    curl \
     python3-pip \
-    python{PYTHON_VERSION} \
-    python{PYTHON_VERSION}-dev \
-    python{PYTHON_VERSION}-distutils && \
+    python${PYTHON_VERSION} \
+    python${PYTHON_VERSION}-dev \
+    python${PYTHON_VERSION}-distutils && \
     rm -rf /var/lib/apt/lists/*
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -68,7 +69,7 @@ RUN useradd -m --shell /bin/false app
 
 RUN mkdir -p requirements
 
-RUN virtualenv -p python{PYTHON_VERSION} --always-copy ${NOTES_VENV_DIR}
+RUN virtualenv -p python${PYTHON_VERSION} --always-copy ${NOTES_VENV_DIR}
 
 RUN pip install --upgrade pip setuptools
 


### PR DESCRIPTION
## Description
- `edx-notes-api` repository has dropped support for `Python 3.8` which caused the docker-publish workflow to fail.
- Updated the `Dockerfile` to use `Python 3.12` to fix the failing build

## Testing
- Tested the workflow on the PR to successfully build and push a test image 
![image](https://github.com/user-attachments/assets/737ff5fc-84f7-4122-99e1-07cab29afd2b)
