### PR TITLE
fix: fix Dockerfile run command

### DIFF
--- a/dockerfiles/edx-notes-api.Dockerfile
+++ b/dockerfiles/edx-notes-api.Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
-RUN locale-gen=en_US.UTF-8
+RUN locale-gen en_US.UTF-8
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8


### PR DESCRIPTION
## Description
- Reverted the refactoring mistakenly done on the `RUN` command instead of only `ARG` and `ENV` variable declarations.