### PR TITLE
build: update WORKDIR in enterprise IDAs

### DIFF
--- a/.github/workflows/push-license-manager-image.yaml
+++ b/.github/workflows/push-license-manager-image.yaml
@@ -43,6 +43,7 @@ jobs:
           push: true
           target: app
           tags: edxops/license-manager-dev:${{ steps.get-tag-name.outputs.result }}
+          platforms: linux/amd64,linux/arm64
 
       # Commenting the notification section temporarily as we don't have the owning team email for titans yet.
       # - name: Send failure notification

--- a/dockerfiles/enterprise-catalog.Dockerfile
+++ b/dockerfiles/enterprise-catalog.Dockerfile
@@ -70,6 +70,7 @@ EXPOSE 8161
 
 RUN useradd -m --shell /bin/false app
 
+WORKDIR /edx/app/enterprise-catalog
 
 RUN curl -L -o requirements/production.txt https://raw.githubusercontent.com/openedx/enterprise-catalog/master/requirements/production.txt
 RUN pip install -r requirements/production.txt

--- a/dockerfiles/enterprise-subsidy.Dockerfile
+++ b/dockerfiles/enterprise-subsidy.Dockerfile
@@ -80,6 +80,7 @@ ENV DJANGO_SETTINGS_MODULE=enterprise_subsidy.settings.production
 
 EXPOSE 18280
 RUN useradd -m --shell /bin/false app
+WORKDIR /edx/app/enterprise-subsidy
 
 # Dependencies are installed as root so they cannot be modified by the application user.
 


### PR DESCRIPTION
## Description
- Updated Dockerfiles for `enterprise-catalog` and `enterprise-subsidy` to include `WORKDIR` in it
- Adding this path should resolve the `gunicorn` and `manage.py` issues in the container
- Updated `license-manager` IDA image workflow to push for both platforms similar to the other enterprise IDAs.