### PR TITLE
fix: fix commands order in dockerfiles

### DIFF
--- a/dockerfiles/enterprise-catalog.Dockerfile
+++ b/dockerfiles/enterprise-catalog.Dockerfile
@@ -50,8 +50,6 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION}
 RUN pip install virtualenv
 
-RUN mkdir -p requirements
-
 ENV VIRTUAL_ENV=/venv
 RUN virtualenv -p python$PYTHON_VERSION $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
@@ -71,6 +69,7 @@ EXPOSE 8161
 RUN useradd -m --shell /bin/false app
 
 WORKDIR /edx/app/enterprise-catalog
+RUN mkdir -p requirements
 
 RUN curl -L -o requirements/production.txt https://raw.githubusercontent.com/openedx/enterprise-catalog/master/requirements/production.txt
 RUN pip install -r requirements/production.txt

--- a/dockerfiles/enterprise-subsidy.Dockerfile
+++ b/dockerfiles/enterprise-subsidy.Dockerfile
@@ -65,8 +65,6 @@ RUN rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION}
 RUN pip install virtualenv
 
-RUN mkdir -p requirements
-
 # Create a virtualenv for sanity
 ENV VIRTUAL_ENV=/edx/venvs/enterprise-subsidy
 RUN virtualenv -p python${PYTHON_VERSION} $VIRTUAL_ENV
@@ -81,6 +79,7 @@ ENV DJANGO_SETTINGS_MODULE=enterprise_subsidy.settings.production
 EXPOSE 18280
 RUN useradd -m --shell /bin/false app
 WORKDIR /edx/app/enterprise-subsidy
+RUN mkdir -p requirements
 
 # Dependencies are installed as root so they cannot be modified by the application user.
 


### PR DESCRIPTION
## Description
- `mkdir` for requirements needs to be placed after the `WORKDIR` declaration for the paths to be functional.