### PR TITLE
Revert "fix: update enterprise-catalog WORKDIR"

### DIFF
--- a/dockerfiles/enterprise-catalog.Dockerfile
+++ b/dockerfiles/enterprise-catalog.Dockerfile
@@ -68,8 +68,7 @@ EXPOSE 8161
 
 RUN useradd -m --shell /bin/false app
 
-WORKDIR /edx/app/enterprise-catalog/enterprise-catalog
-
+WORKDIR /edx/app/enterprise-catalog
 RUN mkdir -p requirements
 
 RUN curl -L -o requirements/production.txt https://raw.githubusercontent.com/openedx/enterprise-catalog/master/requirements/production.txt


### PR DESCRIPTION
Reverts edx/public-dockerfiles#61

The PATH update has already been handled everywhere else so we don't need this change now as fixing this now will need us to revert all those pipeline changes in ArgoCD and edx-internal pipelines (see [thread](https://twou.slack.com/archives/C0495EETUVC/p1731942876492789))