### PR TITLE
build: remove distuils installation in Dockerfile

### DIFF
--- a/dockerfiles/enterprise-catalog.Dockerfile
+++ b/dockerfiles/enterprise-catalog.Dockerfile
@@ -42,7 +42,6 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  wget \
  python3.12 \
  python3.12-dev \
- python3.12-distutils \
  python3-pip
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone


### PR DESCRIPTION
## Description
- Removing the `distutils` installation from dockerfile to fix the ongoing build failure