### PR TITLE
chore: removed distutils package from dockerfiles

### DIFF
--- a/.github/workflows/push-course-discovery-image.yaml
+++ b/.github/workflows/push-course-discovery-image.yaml
@@ -6,7 +6,6 @@ on:
       branch:
         description: "Target branch from which the source dockerfile from image will be sourced"
 
-
   schedule:
     - cron: "0 4 * * 1-5"  # UTC Time
 

--- a/.github/workflows/push-course-discovery-image.yaml
+++ b/.github/workflows/push-course-discovery-image.yaml
@@ -6,6 +6,7 @@ on:
       branch:
         description: "Target branch from which the source dockerfile from image will be sourced"
 
+
   schedule:
     - cron: "0 4 * * 1-5"  # UTC Time
 

--- a/dockerfiles/course-discovery.Dockerfile
+++ b/dockerfiles/course-discovery.Dockerfile
@@ -27,8 +27,7 @@ RUN apt-get update && \
   libcairo2-dev \
   python3-pip \
   python${PYTHON_VERSION} \
-  python${PYTHON_VERSION}-dev \
-  python${PYTHON_VERSION}-distutils && \
+  python${PYTHON_VERSION}-dev && \
   rm -rf /var/lib/apt/lists/*
 
 # Use UTF-8.

--- a/dockerfiles/edx-exams.Dockerfile
+++ b/dockerfiles/edx-exams.Dockerfile
@@ -49,8 +49,7 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  curl \
  python3-pip \
  python${PYTHON_VERSION} \
- python${PYTHON_VERSION}-dev \
- python${PYTHON_VERSION}-distutils
+ python${PYTHON_VERSION}-dev
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/dockerfiles/edx-notes-api.Dockerfile
+++ b/dockerfiles/edx-notes-api.Dockerfile
@@ -41,8 +41,7 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
     curl \
     python3-pip \
     python${PYTHON_VERSION} \
-    python${PYTHON_VERSION}-dev \
-    python${PYTHON_VERSION}-distutils && \
+    python${PYTHON_VERSION}-dev && \
     rm -rf /var/lib/apt/lists/*
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/dockerfiles/enterprise-access.Dockerfile
+++ b/dockerfiles/enterprise-access.Dockerfile
@@ -53,8 +53,7 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  libsqlite3-dev \
  python3-pip \
  python${PYTHON_VERSION} \
- python${PYTHON_VERSION}-dev \
- python${PYTHON_VERSION}-distutils
+ python${PYTHON_VERSION}-dev
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/dockerfiles/enterprise-subsidy.Dockerfile
+++ b/dockerfiles/enterprise-subsidy.Dockerfile
@@ -53,8 +53,7 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  libsqlite3-dev \
  python3-pip \
  python${PYTHON_VERSION} \
- python${PYTHON_VERSION}-dev \
- python${PYTHON_VERSION}-distutils
+ python${PYTHON_VERSION}-dev
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/dockerfiles/license-manager.Dockerfile
+++ b/dockerfiles/license-manager.Dockerfile
@@ -53,8 +53,7 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  libsqlite3-dev \
  python3-pip \
  python${PYTHON_VERSION} \
- python${PYTHON_VERSION}-dev \
- python${PYTHON_VERSION}-distutils
+ python${PYTHON_VERSION}-dev
 
 # Use virtualenv pypi package with Python 3.12
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION}

--- a/dockerfiles/portal-designer.Dockerfile
+++ b/dockerfiles/portal-designer.Dockerfile
@@ -28,8 +28,7 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  curl \
  python3-pip \
  python${PYTHON_VERSION} \
- python${PYTHON_VERSION}-dev \
- python${PYTHON_VERSION}-distutils
+ python${PYTHON_VERSION}-dev
 
 RUN pip install --upgrade pip setuptools
 # delete apt package lists because we do not need them inflating our image

--- a/dockerfiles/program-intent-engagement.Dockerfile
+++ b/dockerfiles/program-intent-engagement.Dockerfile
@@ -48,8 +48,7 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  curl \
  python3-pip \
  python${PYTHON_VERSION} \
- python${PYTHON_VERSION}-dev \
- python${PYTHON_VERSION}-distutils
+ python${PYTHON_VERSION}-dev
 
 
 # need to use virtualenv pypi package with Python 3.12

--- a/dockerfiles/registrar.Dockerfile
+++ b/dockerfiles/registrar.Dockerfile
@@ -26,8 +26,7 @@ RUN apt-get install -qy \
 	curl \
 	python3-pip \
 	python${PYTHON_VERSION} \
-	python${PYTHON_VERSION}-dev \
-	python${PYTHON_VERSION}-distutils
+	python${PYTHON_VERSION}-dev
 
 # need to use virtualenv pypi package with Python 3.12
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION}


### PR DESCRIPTION
## Description
- Python 3.12.8 has [dropped](https://www.python.org/downloads/release/python-3128/) the deprecated distutils module which has caused some pipelines build to fail.