### PR TITLE
chore: added workflow to push portal-designer image

### DIFF
--- a/.github/workflows/push-designer-image.yaml
+++ b/.github/workflows/push-designer-image.yaml
@@ -1,0 +1,62 @@
+name: Build and Push Credentials Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Target branch from which the source dockerfile from image will be sourced"
+
+  schedule:
+    - cron: "0 4 * * 1-5"  # UTC Time
+
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get tag name
+        id: get-tag-name
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const tagName = "${{ github.event.inputs.branch }}" || 'latest';
+            console.log('Will use tag: ' + tagName);
+            return tagName;
+          result-encoding: string
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push Dev Docker image
+        uses: docker/build-push-action@v6
+        with:
+          file: ./dockerfiles/portal-designer.Dockerfile
+          push: true
+          target: devstack
+          tags: edxops/designer-dev:${{ steps.get-tag-name.outputs.result }}
+          platforms: linux/amd64,linux/arm64
+
+#      - name: Send failure notification
+#        if: failure()
+#        uses: dawidd6/action-send-mail@v3
+#        with:
+#          server_address: email-smtp.us-east-1.amazonaws.com
+#          server_port: 465
+#          username: ${{secrets.edx_smtp_username}}
+#          password: ${{secrets.edx_smtp_password}}
+#          subject: Push Image to docker.io/edxops failed in credentials
+#          to: team-cosmonauts@edx.org
+#          from: github-actions <github-actions@edx.org>
+#          body: Push Image to docker.io/edxops for credentials failed! For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/push-designer-image.yaml
+++ b/.github/workflows/push-designer-image.yaml
@@ -9,9 +9,6 @@ on:
   schedule:
     - cron: "0 4 * * 1-5"  # UTC Time
 
-  pull_request:
-    branches: [ main ]
-
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
@@ -48,15 +45,15 @@ jobs:
           tags: edxops/designer-dev:${{ steps.get-tag-name.outputs.result }}
           platforms: linux/amd64,linux/arm64
 
-#      - name: Send failure notification
-#        if: failure()
-#        uses: dawidd6/action-send-mail@v3
-#        with:
-#          server_address: email-smtp.us-east-1.amazonaws.com
-#          server_port: 465
-#          username: ${{secrets.edx_smtp_username}}
-#          password: ${{secrets.edx_smtp_password}}
-#          subject: Push Image to docker.io/edxops failed in credentials
-#          to: team-cosmonauts@edx.org
-#          from: github-actions <github-actions@edx.org>
-#          body: Push Image to docker.io/edxops for credentials failed! For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      - name: Send failure notification
+        if: failure()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: email-smtp.us-east-1.amazonaws.com
+          server_port: 465
+          username: ${{secrets.edx_smtp_username}}
+          password: ${{secrets.edx_smtp_password}}
+          subject: Push Image to docker.io/edxops failed in credentials
+          to: team-cosmonauts@edx.org
+          from: github-actions <github-actions@edx.org>
+          body: Push Image to docker.io/edxops for credentials failed! For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
Workflow to push image of `portal-designer` wasn't included initially. Now that this has been added to `devstack` it's crucial to push the image to reference the image from `edxops` registry. 
This PR adds the workflow to push `portal-designer` image to dockerhub