### PR TITLE
chore: add owning team emails and document link

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -112,4 +112,4 @@ jobs:
           subject: Push Image to docker.io/edxops failed in ${{matrix.images.name}}
           to: ${{matrix.images.owning_team_email}}
           from: github-actions <github-actions@edx.org>
-          body: Push Image to docker.io/edxops for ${{matrix.images.name}} failed! For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          body: Push Image to docker.io/edxops for ${{matrix.images.name}} failed! For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}. Please refer to this document for troubleshooting guidelines https://2u-internal.atlassian.net/wiki/spaces/AT/pages/1648787501/Troubleshooting+guidelines+in+case+failure+to+publish+docker+image"

--- a/images-data.json
+++ b/images-data.json
@@ -66,7 +66,7 @@
   },
   {
     "dockerfile": "edx-platform",
-    "image_name": "lms-dev",
+    "image_name": "lms",
     "name": "lms",
     "os_platform": "linux/amd64,linux/arm64",
     "target": "development",

--- a/images-data.json
+++ b/images-data.json
@@ -3,37 +3,43 @@
     "image_name": "commerce-coordinator",
     "name": "commerce coordinator",
     "os_platform": "linux/arm64",
-    "target": "app"
+    "target": "app",
+    "owning_team_email": "sonic-team@2u.com"
   },
   {
     "image_name": "course-discovery",
     "name": "course discovery",
     "os_platform": "linux/arm64",
-    "target": "dev"
+    "target": "dev",
+    "owning_team_email": "course-discovery@2u-internal.opsgenie.net"
   },
   {
     "image_name": "credentials",
     "name": "credentials",
     "os_platform": "linux/arm64",
-    "target": "dev"
+    "target": "dev",
+    "owning_team_email": "aperture@2u-internal.opsgenie.net"
   },
   {
     "image_name": "ecommerce",
     "name": "ecommerce",
     "os_platform": "linux/arm64",
-    "target": "dev"
+    "target": "dev",
+    "owning_team_email": "sonic-team@2u.com"
   },
   {
     "image_name": "edx-analytics-data-api",
     "name": "edx analytics data api",
     "os_platform": "linux/arm64",
-    "target": "dev"
+    "target": "dev",
+    "owning_team_email": "team-cosmonauts@edx.org"
   },
   {
     "image_name": "edx-exams",
     "name": "edx exams",
     "os_platform": "linux/arm64",
-    "target": "app"
+    "target": "app",
+    "owning_team_email": "team-cosmonauts@edx.org"
   },
   {
     "dockerfile": "edx-platform",
@@ -55,11 +61,12 @@
     "build_args": {
       "SERVICE_VARIANT": "cms",
       "SERVICE_PORT": "18010"
-    }
+    },
+    "owning_team_email": "arch-bom@edx.org"
   },
   {
     "dockerfile": "edx-platform",
-    "image_name": "lms",
+    "image_name": "lms-dev",
     "name": "lms",
     "os_platform": "linux/amd64,linux/arm64",
     "target": "development",
@@ -77,62 +84,72 @@
     "build_args": {
       "SERVICE_VARIANT": "lms",
       "SERVICE_PORT": "18000"
-    }
+    },
+    "owning_team_email": "arch-bom@edx.org"
   },
   {
     "image_name": "edx-notes-api",
     "name": "edx notes api",
     "os_platform": "linux/arm64",
-    "target": "dev"
+    "target": "dev",
+    "owning_team_email": "aurora-docker-alerts@2u-internal.opsgenie.net"
   },
   {
     "image_name": "enterprise-access",
     "name": "enterprise access",
     "os_platform": "linux/arm64",
-    "target": "devstack"
+    "target": "devstack",
+    "owning_team_email": "enterprise_alerts@2u-internal.opsgenie.net"
   },
   {
     "image_name": "enterprise-catalog",
     "name": "enterprise catalog",
     "os_platform": "linux/arm64",
-    "target": "legacy_devapp"
+    "target": "legacy_devapp",
+    "owning_team_email": "enterprise_alerts@2u-internal.opsgenie.net"
   },
   {
     "image_name": "enterprise-subsidy",
     "name": "enterprise subsidy",
     "os_platform": "linux/arm64",
-    "target": "devstack"
+    "target": "devstack",
+    "owning_team_email": "enterprise_alerts@2u-internal.opsgenie.net"
   },
   {
     "image_name": "program-intent-engagement",
     "name": "program intent engagement",
     "os_platform": "linux/arm64",
-    "target": "app"
+    "target": "app",
+    "owning_team_email": "team-cosmonauts@edx.org"
   },
   {
     "image_name": "registrar",
     "name": "registrar",
     "os_platform": "linux/arm64",
-    "target": "dev"
+    "target": "dev",
+    "owning_team_email": "team-cosmonauts@edx.org"
   },
   {
     "image_name": "xqueue",
     "name": "xqueue",
     "os_platform": "linux/arm64",
-    "target": "dev"
+    "target": "dev",
+    "owning_team_email": "aurora-docker-alerts@2u-internal.opsgenie.net"
   },
   {
     "dockerfile": "portal-designer",
     "image_name": "designer-dev",
     "name": "portal designer",
     "os_platform": "linux/amd64,linux/arm64",
-    "target": "devstack"
+    "target": "devstack",
+    "owning_team_email": "team-cosmonauts@edx.org"
   },
   {
     "image_name": "license-manager",
     "name": "license manager",
     "os_platform": "linux/amd64,linux/arm64",
-    "target": "dev"
+    "target": "dev",
+    "owning_team_email": "enterprise_alerts@2u-internal.opsgenie.net"
   },
   {
     "image_name": "codejail",


### PR DESCRIPTION
This PR adds owning team email in images data on which an email alert will be sent in case of failure of workflow. It also adds link to troubleshooting guidelines in email body. 