### PR TITLE
build: update platforms OS for all docker images

### DIFF
--- a/images-data.json
+++ b/images-data.json
@@ -2,37 +2,37 @@
   {
     "image_name": "commerce-coordinator",
     "name": "commerce coordinator",
-    "os_platform": "linux/arm64",
+    "os_platform": "linux/amd64,linux/arm64",
     "target": "app"
   },
   {
     "image_name": "course-discovery",
     "name": "course discovery",
-    "os_platform": "linux/arm64",
+    "os_platform": "linux/amd64,linux/arm64",
     "target": "dev"
   },
   {
     "image_name": "credentials",
     "name": "credentials",
-    "os_platform": "linux/arm64",
+    "os_platform": "linux/amd64,linux/arm64",
     "target": "dev"
   },
   {
     "image_name": "ecommerce",
     "name": "ecommerce",
-    "os_platform": "linux/arm64",
+    "os_platform": "linux/amd64,linux/arm64",
     "target": "dev"
   },
   {
     "image_name": "edx-analytics-data-api",
     "name": "edx analytics data api",
-    "os_platform": "linux/arm64",
+    "os_platform": "linux/amd64,linux/arm64",
     "target": "dev"
   },
   {
     "image_name": "edx-exams",
     "name": "edx exams",
-    "os_platform": "linux/arm64",
+    "os_platform": "linux/amd64,linux/arm64",
     "target": "app"
   },
   {
@@ -82,43 +82,43 @@
   {
     "image_name": "edx-notes-api",
     "name": "edx notes api",
-    "os_platform": "linux/arm64",
+    "os_platform": "linux/amd64,linux/arm64",
     "target": "dev"
   },
   {
     "image_name": "enterprise-access",
     "name": "enterprise access",
-    "os_platform": "linux/arm64",
+    "os_platform": "linux/amd64,linux/arm64",
     "target": "devstack"
   },
   {
     "image_name": "enterprise-catalog",
     "name": "enterprise catalog",
-    "os_platform": "linux/arm64",
+    "os_platform": "linux/amd64,linux/arm64",
     "target": "legacy_devapp"
   },
   {
     "image_name": "enterprise-subsidy",
     "name": "enterprise subsidy",
-    "os_platform": "linux/arm64",
+    "os_platform": "linux/amd64,linux/arm64",
     "target": "devstack"
   },
   {
     "image_name": "program-intent-engagement",
     "name": "program intent engagement",
-    "os_platform": "linux/arm64",
+    "os_platform": "linux/amd64,linux/arm64",
     "target": "app"
   },
   {
     "image_name": "registrar",
     "name": "registrar",
-    "os_platform": "linux/arm64",
+    "os_platform": "linux/amd64,linux/arm64",
     "target": "dev"
   },
   {
     "image_name": "xqueue",
     "name": "xqueue",
-    "os_platform": "linux/arm64",
+    "os_platform": "linux/amd64,linux/arm64",
     "target": "dev"
   },
   {


### PR DESCRIPTION
## Description
- After the consolidation of workflows, updating the architecture platforms for the devstack images to be available on all platforms. 
- This will resolve following error when setting up devstack or pulling images locally 
```
no matching manifest for linux/amd64 in the manifest list entries
make: *** [dev.pull.credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-authn+frontend-app-gradebook+frontend-app-payment+frontend-app-publisher+frontend-app-learning+lms+cms] Error 18
```