### PR TITLE
chore: remove unecessary prod images

### DIFF
--- a/images-data.json
+++ b/images-data.json
@@ -55,18 +55,6 @@
   },
   {
     "dockerfile": "edx-platform",
-    "image_name": "cms-production",
-    "name": "cms-production",
-    "os_platform": "linux/amd64,linux/arm64",
-    "target": "production",
-    "build_args": {
-      "SERVICE_VARIANT": "cms",
-      "SERVICE_PORT": "18010"
-    },
-    "owning_team_email": "arch-bom@edx.org"
-  },
-  {
-    "dockerfile": "edx-platform",
     "image_name": "lms",
     "name": "lms",
     "os_platform": "linux/amd64,linux/arm64",
@@ -75,18 +63,6 @@
       "SERVICE_VARIANT": "lms",
       "SERVICE_PORT": "18000"
     }
-  },
-  {
-    "dockerfile": "edx-platform",
-    "image_name": "lms-production",
-    "name": "lms-production",
-    "os_platform": "linux/amd64,linux/arm64",
-    "target": "production",
-    "build_args": {
-      "SERVICE_VARIANT": "lms",
-      "SERVICE_PORT": "18000"
-    },
-    "owning_team_email": "arch-bom@edx.org"
   },
   {
     "image_name": "edx-notes-api",


### PR DESCRIPTION
Follow up to https://2u-internal.atlassian.net/browse/COSMO-626, removing extraneous "lms-production" and "cms-production" images, as don't actually end up being used for deployments to production.