### PR TITLE
feat: Various codejail improvements for devstack usage

### DIFF
--- a/dockerfiles/codejail.Dockerfile
+++ b/dockerfiles/codejail.Dockerfile
@@ -65,14 +65,11 @@ CMD /venv/bin/gunicorn -c /app/codejail_service/docker_gunicorn_configuration.py
 FROM app AS dev
 
 # Developers will want some additional packages for interactive debugging.
-RUN <<EOF
-set -eu
-apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install  \
-  --quiet --yes --no-install-recommends \
-  make less nano emacs-nox
-rm -rf /var/lib/apt/lists/*
-EOF
+RUN apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install \
+    --quiet --yes --no-install-recommends \
+    make less nano emacs-nox && \
+  rm -rf /var/lib/apt/lists/*
 
 RUN /venv/bin/pip-sync requirements/dev.txt
 RUN python${PYVER} -m compileall /venv


### PR DESCRIPTION
A collection of improvements to enable the usual live-reloading workflow. Running as app meant we couldn't recompile files, modify the container environment, etc.

- Run as root in dev target, for convenience and matching other images
- Use gunicorn for both targets, since in devstack we can specify the CMD in the docker-compose file anyhow.
- Install make, less, and some editors in the dev target
- Set up virtualenv for dev environment