### PR TITLE
fix: Replace heredoc with multi-line RUN instruction

### DIFF
--- a/dockerfiles/codejail.Dockerfile
+++ b/dockerfiles/codejail.Dockerfile
@@ -26,15 +26,10 @@ ARG PYVER=3.12
 # - python*: A specific version of Python
 # - python*-dev: Header files for python extensions, required by many source wheels
 # - python*-venv: Allow creation of virtualenvs
-RUN <<EOF
-apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install \
-  --quiet --yes --no-install-recommends \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --quiet --yes --no-install-recommends \
   language-pack-en locales \
-  python${PYVER} python${PYVER}-dev python${PYVER}-venv
-# If you add a package, please add a comment above explaining why it is needed!
-rm -rf /var/lib/apt/lists/*
-EOF
+  python${PYVER} python${PYVER}-dev python${PYVER}-venv && \
+  rm -rf /var/lib/apt/lists/*
 
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
I am encountering a failure in the GoCD build process due to a Dockerfile parsing error:

```failed to solve with frontend dockerfile.v0: failed to create LLB definition: dockerfile parse error line 30: unknown instruction: APT-GET```
To address this issue, I have restructured the Dockerfile by replacing the heredoc syntax with a standard multi-line RUN instruction, ensuring that each line is properly terminated with a backslash (\) for line continuation
