### PR TITLE
docs: Restore comment and formatting in RUN command for codejail

### DIFF
--- a/dockerfiles/codejail.Dockerfile
+++ b/dockerfiles/codejail.Dockerfile
@@ -26,9 +26,12 @@ ARG PYVER=3.12
 # - python*: A specific version of Python
 # - python*-dev: Header files for python extensions, required by many source wheels
 # - python*-venv: Allow creation of virtualenvs
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --quiet --yes --no-install-recommends \
-  language-pack-en locales \
-  python${PYVER} python${PYVER}-dev python${PYVER}-venv && \
+RUN apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install \
+    --quiet --yes --no-install-recommends \
+    language-pack-en locales \
+    python${PYVER} python${PYVER}-dev python${PYVER}-venv && \
+    # If you add a package, please add a comment above explaining why it is needed!
   rm -rf /var/lib/apt/lists/*
 
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
Tweaks following https://github.com/edx/public-dockerfiles/pull/94

- Restore comment
- Restore line breaks