### PR TITLE
feat: Allow codejail-service webapp to receive kill signal

### DIFF
--- a/apparmor/openedx_codejail_service.profile
+++ b/apparmor/openedx_codejail_service.profile
@@ -56,6 +56,9 @@ profile openedx_codejail_service flags=(mediate_deleted) {
     # runs beyond time limits.
     signal (send) set=(kill) peer=openedx_codejail_service//codejail_sandbox,
 
+    # Allow receiving a kill signal (and other signals) from container orchestration.
+    signal (receive),
+
     # The core of the confinement: When the sandbox Python is executed, switch to
     # the (extremely constrained) codejail_sandbox profile.
     #


### PR DESCRIPTION
A lot of the new pods are in an attempting-termination status with hundreds of the following `FailedKillPod` error event:

`unknown error after kill: runc did not terminate successfully: exit status 1: unable to signal init: permission denied`

I believe the issue is that the outer profile does not allow for receiving signals. Hopefully this will fix it.