### PR TITLE
fix: fix config path in edxapp dockerfile

### DIFF
--- a/dockerfiles/edx-platform.Dockerfile
+++ b/dockerfiles/edx-platform.Dockerfile
@@ -16,8 +16,8 @@ ENV LANGUAGE='en_US:en'
 ENV LC_ALL='en_US.UTF-8'
 
 # Env vars: configuration
-ENV LMS_CFG="$CONFIG_ROOT/lms.yml"
-ENV CMS_CFG="$CONFIG_ROOT/cms.yml"
+ENV LMS_CFG="/edx/etc/lms.yml"
+ENV CMS_CFG="/edx/etc/cms.yml"
 
 # Env vars: path
 ENV VIRTUAL_ENV="/edx/app/edxapp/venvs/edxapp"


### PR DESCRIPTION
## Description
- In the previous PR `$CONFIG_ROOT` variable was removed which caused the env paths to be wrong and caused following error when setting up devstack

```
  py38-django32-migrate: commands succeeded
  congratulations :)
docker compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && make migrate-lms'
python manage.py lms showmigrations --database default --traceback --pythonpath=.
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/manage.py", line 99, in <module>
    execute_from_command_line([sys.argv[0]] + django_args)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/core/management/__init__.py", line 382, in execute
    settings.INSTALLED_APPS
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/conf/__init__.py", line 102, in __getattr__
    self._setup(name)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/conf/__init__.py", line 89, in _setup
    self._wrapped = Settings(settings_module)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/conf/__init__.py", line 217, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/edx/app/edxapp/edx-platform/lms/envs/devstack_docker.py", line 9, in <module>
    from .devstack import *  # pylint: disable=wildcard-import, unused-wildcard-import
    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/edx-platform/lms/envs/devstack.py", line 16, in <module>
    from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/edx-platform/lms/envs/production.py", line 170, in <module>
    with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen codecs>", line 918, in open
FileNotFoundError: [Errno 2] No such file or directory: '/edx/etc/lms.yml'
make: *** [Makefile:159: migrate-lms] Error 1
```
- Updated the env paths for both lms and cms 