### PR TITLE
chore: update Node to v20.x and npm to 11.x in Credentials Dockerfile

### DIFF
--- a/dockerfiles/credentials.Dockerfile
+++ b/dockerfiles/credentials.Dockerfile
@@ -66,9 +66,9 @@ ENV LC_ALL=en_US.UTF-8
 # Create Node env
 RUN pip install nodeenv
 ENV NODE_ENV=/edx/app/credentials/nodeenvs/credentials
-RUN nodeenv $NODE_ENV --node=18.20.7 --prebuilt
+RUN nodeenv $NODE_ENV --node=20.19.0 --prebuilt
 ENV PATH="$NODE_ENV/bin:$PATH"
-RUN npm install -g npm@9.x.x
+RUN npm install -g npm@11.x.x
 
 ENV DJANGO_SETTINGS_MODULE=credentials.settings.production
 ENV OPENEDX_ATLAS_PULL=true


### PR DESCRIPTION
We are currently still installing Node 18 and npm 9.x when creating an image for the Credentials IDA. Node 18 is officially EOL on April 30th, 2025.

This PR updates the version of Node and NPM to their latest respective versions for Node 20.x.