### PR TITLE
feat: Switch codejail-service sandbox deps to teak

### DIFF
--- a/dockerfiles/codejail-service.Dockerfile
+++ b/dockerfiles/codejail-service.Dockerfile
@@ -48,7 +48,7 @@ ARG SANDBOX_DEPS_VERSION=master
 # to be coordinated with SANDBOX_PY_VER as each release has a
 # different Python support window.
 ARG SANDBOX_DEPS_SRC_DIR=requirements/edx-sandbox/releases
-ARG SANDBOX_DEPS_SRC_FILE=sumac.txt
+ARG SANDBOX_DEPS_SRC_FILE=teak.txt
 
 # Python version for sandboxed executions. This must be coordinated with
 # `SANDBOX_DEPS_SRC_*` to ensure compatibility.


### PR DESCRIPTION
Teak has now been released, so we can use the newer lockfile.