### PR TITLE
Revert "feat: Ensure that the vendor JS and CSS are built."

### DIFF
--- a/dockerfiles/edx-platform.Dockerfile
+++ b/dockerfiles/edx-platform.Dockerfile
@@ -164,9 +164,6 @@ COPY --from=builder-production /edx/app/edxapp/edx-platform/node_modules /edx/ap
 # Copy over remaining parts of repository (including all code)
 ADD https://github.com/openedx/edx-platform.git#${EDX_PLATFORM_VERSION} .
 
-# Pull out the vendor JS and CSS from the node modules.
-RUN npm run postinstall
-
 # Install Python requirements again in order to capture local projects
 RUN pip install -e .
 


### PR DESCRIPTION
Reverts edx/public-dockerfiles#125

As part of continue efforts on collect static, we are going to keep all of this code together in the internal dockerfile for now. See the ticket: 
- https://github.com/edx/edx-arch-experiments/issues/1032

This revert is simply being moved to the internal dockerfile.