### PR TITLE
fix: add production stage to enterprise-access

### DIFF
--- a/dockerfiles/enterprise-access.Dockerfile
+++ b/dockerfiles/enterprise-access.Dockerfile
@@ -110,12 +110,11 @@ USER app
 # Gunicorn 19 does not log to stdout or stderr by default. Once we are past gunicorn 19, the logging to STDOUT need not be specified.
 CMD gunicorn --workers=2 --name enterprise-access -c /edx/app/enterprise-access/enterprise_access/docker_gunicorn_configuration.py --log-file - --max-requests=1000 enterprise_access.wsgi:application
 
-FROM app AS newrelic
-RUN pip install newrelic
-CMD newrelic-admin run-program gunicorn --workers=2 --name enterprise-access -c /edx/app/enterprise-access/enterprise_access/docker_gunicorn_configuration.py --log-file - --max-requests=1000 enterprise_access.wsgi:application
-
 FROM app AS devstack
 USER root
 RUN pip install -r requirements/dev.txt
+USER app
+CMD gunicorn --workers=2 --name enterprise-access -c /edx/app/enterprise-access/enterprise_access/docker_gunicorn_configuration.py --log-file - --max-requests=1000 enterprise_access.wsgi:application
 
+FROM app as production
 CMD gunicorn --workers=2 --name enterprise-access -c /edx/app/enterprise-access/enterprise_access/docker_gunicorn_configuration.py --log-file - --max-requests=1000 enterprise_access.wsgi:application


### PR DESCRIPTION
...so that subsequent internal Dockerfiles will inherit the production stage by default.  Devstack/docker-compose can continue to use the devstack stage by manually referencing the `devstack` target.