### PR TITLE
Revert "feat: update Credentials Dockerfile to support repeated rebui…

### DIFF
--- a/dockerfiles/credentials.Dockerfile
+++ b/dockerfiles/credentials.Dockerfile
@@ -1,7 +1,5 @@
 FROM ubuntu:focal AS base
 
-ARG CREDENTIALS_SERVICE_REPO=openedx/credentials
-ARG CREDENTIALS_SERVICE_VERSION=master
 ARG PYTHON_VERSION=3.12
 ENV TZ=UTC
 ENV TERM=xterm-256color
@@ -91,9 +89,6 @@ RUN chmod 2777 /usr/local/var/run/watchman
 # Now install credentials
 WORKDIR /edx/app/credentials/credentials
 
-# Cloning git repo.
-ADD https://github.com/${CREDENTIALS_SERVICE_REPO}.git#${CREDENTIALS_SERVICE_VERSION} /edx/app/credentials/credentials
-
 # fetching the requirement files that are needed
 RUN mkdir -p requirements
 RUN curl -L -o requirements/pip_tools.txt https://raw.githubusercontent.com/openedx/credentials/master/requirements/pip_tools.txt
@@ -104,6 +99,9 @@ RUN pip install -r requirements/pip_tools.txt
 RUN pip install -r requirements/production.txt
 
 RUN mkdir -p /edx/var/log
+
+# Cloning git repo. This line is after the python requirements so that changes to the code will not bust the image cache
+RUN curl -L https://github.com/openedx/credentials/archive/refs/heads/master.tar.gz | tar -xz --strip-components=1
 
 # Fetch the translations into the image once the Makefile's in place
 RUN make pull_translations
@@ -130,7 +128,7 @@ USER root
 
 RUN curl -L -o credentials/settings/devstack.py https://raw.githubusercontent.com/edx/devstack/master/py_configuration_files/credentials.py
 
-ENV DJANGO_SETTINGS_MODULE=credentials.settings.devstack
+ENV DJANGO_SETTINGS_MODULE credentials.settings.devstack
 RUN pip install -r /edx/app/credentials/credentials/requirements/dev.txt
 RUN make pull_translations
 


### PR DESCRIPTION
This reverts commit 106dc232974720c6ac2af6bcbc8e0d5dabbd41f3.

When running the build in GoCD, we're failing to run the `pull_translations` Makefile target and need to do some more local debugging.