### PR TITLE
chore: remove newrelic installation from enterprise builds

### DIFF
--- a/dockerfiles/enterprise-catalog.Dockerfile
+++ b/dockerfiles/enterprise-catalog.Dockerfile
@@ -83,14 +83,6 @@ USER app
 # Gunicorn 19 does not log to stdout or stderr by default. Once we are past gunicorn 19, the logging to STDOUT need not be specified.
 CMD gunicorn --workers=2 --name enterprise_catalog -c /edx/app/enterprise-catalog/enterprise_catalog/docker_gunicorn_configuration.py --log-file - --max-requests=1000 enterprise_catalog.wsgi:application
 
-###############################################################
-# Create newrelic image used by the experimental docker shim. #
-###############################################################
-# TODO: remove this after we migrate to k8s since it will serve no more purpose.
-FROM app AS newrelic
-RUN pip install newrelic
-CMD ["newrelic-admin", "run-program", "gunicorn", "--workers=2", "--name", "enterprise_catalog", "-c", "/edx/app/enterprise_catalog/enterprise_catalog/enterprise_catalog/docker_gunicorn_configuration.py", "--log-file", "-", "--max-requests=1000", "enterprise_catalog.wsgi:application"]
-
 #################################
 # Create image used by devstack #
 #################################

--- a/dockerfiles/enterprise-subsidy.Dockerfile
+++ b/dockerfiles/enterprise-subsidy.Dockerfile
@@ -100,11 +100,6 @@ USER app
 # Gunicorn 19 does not log to stdout or stderr by default. Once we are past gunicorn 19, the logging to STDOUT need not be specified.
 CMD gunicorn --workers=2 --name enterprise-subsidy -c /edx/app/enterprise-subsidy/enterprise_subsidy/docker_gunicorn_configuration.py --log-file - --max-requests=1000 enterprise_subsidy.wsgi:application
 
-
-FROM app AS newrelic
-RUN pip install newrelic
-CMD gunicorn --workers=2 --name enterprise-subsidy -c /edx/app/enterprise-subsidy/enterprise_subsidy/docker_gunicorn_configuration.py --log-file - --max-requests=1000 enterprise_subsidy.wsgi:application
-
 FROM app AS devstack
 USER root
 RUN pip install -r requirements/dev.txt

--- a/dockerfiles/license-manager.Dockerfile
+++ b/dockerfiles/license-manager.Dockerfile
@@ -106,12 +106,6 @@ USER app
 # Gunicorn 19 does not log to stdout or stderr by default. Once we are past gunicorn 19, the logging to STDOUT need not be specified.
 CMD gunicorn --workers=2 --name license_manager -c /edx/app/license_manager/license_manager/docker_gunicorn_configuration.py --log-file - --max-requests=1000 license_manager.wsgi:application
 
-
-FROM app as newrelic
-RUN pip install newrelic
-CMD newrelic-admin run-program gunicorn --workers=2 --name license_manager -c /edx/app/license_manager/license_manager/docker_gunicorn_configuration.py --log-file - --max-requests=1000 license_manager.wsgi:application
-
-
 FROM app as dev
 USER root
 RUN pip install -r /edx/app/license_manager/requirements/dev.txt


### PR DESCRIPTION
Currently, this PR aims to resolve the failing build pipeline in enterprise-catalog by removing the installation of newrelic from the build process for `enterprise-catalog`

To avoid this error from occurring in similar builds in enterprise, I am removing references to installing newrelic in `enterprise-subsidy` and `license-manager`

Related ticket: https://github.com/edx/internal-dockerfiles/pull/180