### PR TITLE
fix: upgraded python version 3.8 to 3.11 for xqueue

### DIFF
--- a/dockerfiles/xqueue.Dockerfile
+++ b/dockerfiles/xqueue.Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get upgrade -qy && \
     pkg-config wget unzip && \
     rm -rf /var/lib/apt/lists/*
 
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VERSION} 1
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1
 
 # need to use virtualenv pypi package with Python 3.11


### PR DESCRIPTION
### PR Description: 
 
This PR was done as a part of  [BOMS-42](https://2u-internal.atlassian.net/browse/BOMS-42)
 
### Screenshot for test in xqueue repo:

<img width="1432" height="872" alt="image" src="https://github.com/user-attachments/assets/3037b4f0-5814-4850-a798-69faebe8f2aa" />

<img width="1432" height="758" alt="image" src="https://github.com/user-attachments/assets/27cee891-dd8a-4a7c-a027-ffafbd44d264" />

<img width="1429" height="554" alt="image" src="https://github.com/user-attachments/assets/af3db672-2863-4a2a-ae9d-056d51f34b17" />
