### PR TITLE
fix: Remove attempt to add minimal lms and cms files.

### DIFF
--- a/dockerfiles/edx-platform.Dockerfile
+++ b/dockerfiles/edx-platform.Dockerfile
@@ -255,9 +255,6 @@ RUN apt-get update && \
 # Overwrite production packages with development ones
 COPY --from=builder-development /edx/app/edxapp/venvs/edxapp /edx/app/edxapp/venvs/edxapp
 
-RUN ln -s "$(pwd)/lms/envs/minimal.yml" "$LMS_CFG"
-RUN ln -s "$(pwd)/cms/envs/minimal.yml" "$CMS_CFG"
-
 # Add in a dummy ../edxapp_env file
 RUN touch ../edxapp_env
 


### PR DESCRIPTION
We were using this with the old devstack-experimental files. We can mount these in devstack without doing this hack.