### PR TITLE
fix: Add missing version arg for edxapp

### DIFF
--- a/dockerfiles/edx-platform.Dockerfile
+++ b/dockerfiles/edx-platform.Dockerfile
@@ -173,6 +173,8 @@ COPY --from=builder-production /edx/app/edxapp/venvs/edxapp /edx/app/edxapp/venv
 COPY --from=builder-production /edx/app/edxapp/nodeenv /edx/app/edxapp/nodeenv
 COPY --from=builder-production /edx/app/edxapp/edx-platform/node_modules /edx/app/edxapp/edx-platform/node_modules
 
+ARG EDX_PLATFORM_VERSION
+
 # Copy over remaining parts of repository (including all code)
 ADD https://github.com/openedx/edx-platform.git#${EDX_PLATFORM_VERSION} .
 


### PR DESCRIPTION
This is needed because `minimal-system` doesn't provide the arg; it needs to be redeclared here. (The build was giving a warning.)

We would have caught this if we had warnings enabled. Filed https://2u-internal.atlassian.net/browse/BOMS-219