### PR TITLE
feat: Make codejail Dockerfile build with no args; start linting

### DIFF
--- a/.github/workflows/check-docker.sh
+++ b/.github/workflows/check-docker.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Check Docker images for warnings and syntax errors.
+set -eu -o pipefail
+
+# Paths to Dockerfiles that haven't yet had warnings and errors dealt with. Once
+# your Dockerfile builds without warnings, remove it from this list.
+function is_amnesty_path {
+    grep -F -q -x "$1" <<EOF
+./dockerfiles/commerce-coordinator.Dockerfile
+./dockerfiles/course-discovery.Dockerfile
+./dockerfiles/credentials.Dockerfile
+./dockerfiles/ecommerce.Dockerfile
+./dockerfiles/edx-analytics-dashboard.Dockerfile
+./dockerfiles/edx-analytics-data-api.Dockerfile
+./dockerfiles/edx-exams.Dockerfile
+./dockerfiles/edx-notes-api.Dockerfile
+./dockerfiles/edx-platform.Dockerfile
+./dockerfiles/enterprise-access.Dockerfile
+./dockerfiles/enterprise-catalog.Dockerfile
+./dockerfiles/enterprise-subsidy.Dockerfile
+./dockerfiles/license-manager.Dockerfile
+./dockerfiles/portal-designer.Dockerfile
+./dockerfiles/program-intent-engagement.Dockerfile
+./dockerfiles/registrar.Dockerfile
+./dockerfiles/xqueue.Dockerfile
+EOF
+}
+
+
+find . -name '*Dockerfile' | while IFS= read -r path; do
+    if is_amnesty_path "$path"; then
+        echo "Skipping $path"
+    else
+        echo "Checking $path"
+        docker build --check --quiet -f "$path" .
+    fi
+    echo "======================================================================"
+done

--- a/.github/workflows/check-docker.yml
+++ b/.github/workflows/check-docker.yml
@@ -1,0 +1,15 @@
+name: Check for docker warnings
+on:
+  - pull_request
+defaults:
+  run:
+    shell: bash # making this explicit opts into -e -o pipefail
+jobs:
+  check_docker_warnings:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Run checker
+      run: .github/workflows/check-docker.sh

--- a/dockerfiles/codejail-service.Dockerfile
+++ b/dockerfiles/codejail-service.Dockerfile
@@ -170,11 +170,6 @@ RUN { \
 # knowing where the virtualenv is located.
 ENV PATH="/venv/bin:$PATH"
 
-EXPOSE 8080
-CMD /venv/bin/gunicorn -c /app/codejail_service/docker_gunicorn_configuration.py \
-    --bind '0.0.0.0:8080' --workers=10 --max-requests=1000 \
-    codejail_service.wsgi:application
-
 
 ##### Development target #####
 


### PR DESCRIPTION
This commit adds CI checks for Dockerfiles, starting with the codejail service. To make it build without errors and warnings, I had to remove the string-based `CMD` directive. It was causing a `JSONArgsRecommended` warning, but rather than switch to JSON args, I believe we should just remove the CMD entirely -- we already override this in our devstack compose file, and it's confusing to have this unused value.

BOMS-219