### PR TITLE
feat: course-discovery install jammy

### DIFF
--- a/dockerfiles/course-discovery.Dockerfile
+++ b/dockerfiles/course-discovery.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal AS app
+FROM ubuntu:jammy AS app
 
 ARG PYTHON_VERSION=3.12
 


### PR DESCRIPTION
Upgrades the course-discovery Dockerfile base image from ubuntu:focal → ubuntu:jammy.

Verified local build inside Codespaces :
- python3 --version → 3.12.11
- pip --version → 25.2