### PR TITLE
feat: credentials install ubuntu jammy

### DIFF
--- a/dockerfiles/credentials.Dockerfile
+++ b/dockerfiles/credentials.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv
 # SecretsUsedInArgOrEnv check gets false positives on the name CREDENTIALS
-FROM ubuntu:focal AS base
+FROM ubuntu:jammy AS base
 
 ARG CREDENTIALS_SERVICE_REPO=openedx/credentials
 ARG CREDENTIALS_SERVICE_VERSION=master


### PR DESCRIPTION
Inspired by the upgrade by Enterprise team (https://github.com/edx/public-dockerfiles/pull/171), it's possible that we needed to update Credentials IDA to a more recent version of Ubuntu in order to stay on a supported version.