### PR TITLE
feat: override tracking log handler to write directly to EFS

### DIFF
--- a/dockerfiles/edx-platform.Dockerfile
+++ b/dockerfiles/edx-platform.Dockerfile
@@ -268,6 +268,13 @@ RUN <<EOCMD
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
 from openedx.core.lib.logsettings import get_docker_logger_config
 LOGGING = get_docker_logger_config()
+TRACKING_LOG_DIR="/edx/var/log/tracking.log"
+LOGGING["handlers"]["tracking"] = {
+    'level': 'DEBUG',
+    'class': 'logging.handlers.WatchedFileHandler',
+    'filename': TRACKING_LOG_DIR,
+    'formatter': 'raw',
+}
 EOF
 
     cp lms/envs/docker-production.py cms/envs/docker-production.py

--- a/dockerfiles/edx-platform.Dockerfile
+++ b/dockerfiles/edx-platform.Dockerfile
@@ -268,10 +268,11 @@ RUN <<EOCMD
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
 from openedx.core.lib.logsettings import get_docker_logger_config
 LOGGING = get_docker_logger_config()
+tracking_log_path = os.path.join('/edx/var/log/tracking', os.environ.get('NODE_NAME', 'unknown-node'), os.environ.get('POD_NAME', 'unknown-pod'))
 LOGGING["handlers"]["tracking"] = {
     'level': 'DEBUG',
     'class': 'logging.handlers.WatchedFileHandler',
-    'filename': "/edx/var/log/tracking.log",
+    'filename': os.path.join(tracking_log_path, 'tracking.log'),
     'formatter': 'raw',
 }
 EOF

--- a/dockerfiles/edx-platform.Dockerfile
+++ b/dockerfiles/edx-platform.Dockerfile
@@ -268,11 +268,10 @@ RUN <<EOCMD
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
 from openedx.core.lib.logsettings import get_docker_logger_config
 LOGGING = get_docker_logger_config()
-TRACKING_LOG_DIR="/edx/var/log/tracking.log"
 LOGGING["handlers"]["tracking"] = {
     'level': 'DEBUG',
     'class': 'logging.handlers.WatchedFileHandler',
-    'filename': TRACKING_LOG_DIR,
+    'filename': "/edx/var/log/tracking.log",
     'formatter': 'raw',
 }
 EOF

--- a/dockerfiles/edx-platform.Dockerfile
+++ b/dockerfiles/edx-platform.Dockerfile
@@ -166,6 +166,7 @@ RUN apt-get -y install --no-install-recommends python3-pip
 RUN mkdir -p /edx/var/edxapp
 RUN mkdir -p /edx/etc
 RUN chown app:app /edx/var/edxapp
+RUN mkdir -p /edx/var/log/tracking && chown -R app:app /edx/var/log
 
 
 # The builder-production stage is a temporary stage that installs required packages and builds the python virtualenv,
@@ -268,11 +269,16 @@ RUN <<EOCMD
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
 from openedx.core.lib.logsettings import get_docker_logger_config
 LOGGING = get_docker_logger_config()
-tracking_log_path = os.path.join('/edx/var/log/tracking', os.environ.get('NODE_NAME', 'unknown-node'), os.environ.get('POD_NAME', 'unknown-pod'))
+_tracking_log_dir = os.path.join(
+    '/edx/var/log/tracking',
+    os.environ.get('NODE_NAME', 'unknown-node'),
+    os.environ.get('POD_NAME', 'unknown-pod'),
+)
+os.makedirs(_tracking_log_dir, exist_ok=True)
 LOGGING["handlers"]["tracking"] = {
     'level': 'DEBUG',
     'class': 'logging.handlers.WatchedFileHandler',
-    'filename': os.path.join(tracking_log_path, 'tracking.log'),
+    'filename': os.path.join(_tracking_log_dir, 'tracking.log'),
     'formatter': 'raw',
 }
 EOF


### PR DESCRIPTION
## Summary
This PR updates tracking log configuration in `edx-platform.Dockerfile` by overriding the Django `tracking` handler in generated `docker-production.py` and routing output to per-node/per-pod log files.

**Jira** - [GSRE-3740](https://2u-internal.atlassian.net/browse/GSRE-3740)

## Purpose
Ensure tracking events are written to a deterministic filesystem location that supports pod-level separation and Fluentd tailing patterns in containerized deployments.

## Changes
- Updated generated `lms/envs/docker-production.py` (and copied to CMS) to:
  - Initialize logging with `get_docker_logger_config()`
  - Build `_tracking_log_dir` as:
    - `/edx/var/log/tracking/<NODE_NAME>/<POD_NAME>`
  - Create directory if missing via `os.makedirs(..., exist_ok=True)`
  - Override `LOGGING["handlers"]["tracking"]` with:
    - `logging.handlers.WatchedFileHandler`
    - `filename = os.path.join(_tracking_log_dir, "tracking.log")`
    - `formatter = raw`
- Added image build step to prepare filesystem ownership in non-mounted environments:
  - `RUN mkdir -p /edx/var/log/tracking && chown -R app:app /edx/var/log`