### PR TITLE
feat: Use edx/edx-platform and release-ulmo by default.

### DIFF
--- a/dockerfiles/edx-platform.Dockerfile
+++ b/dockerfiles/edx-platform.Dockerfile
@@ -6,7 +6,7 @@
 
 # This can be overridden with a private fork but you'll need to pass
 # --secret id=GIT_AUTH_TOKEN,env=GITHUB_TOKEN with a GH token in the env.
-ARG EDX_PLATFORM_REPO=openedx/edx-platform
+ARG EDX_PLATFORM_REPO=edx/edx-platform
 
 # These should be overridden with a full commit hash in order to get repeatable,
 # consistent builds.
@@ -18,7 +18,7 @@ ARG EDX_PLATFORM_REPO=openedx/edx-platform
 # need to be converted to ADD commands if you want to be able to pass a branch
 # to this arg and have it work consistently. (The main blocker is places where
 # we want to fetch a single file, because ADD can only fetch entire directories.)
-ARG EDX_PLATFORM_VERSION=master
+ARG EDX_PLATFORM_VERSION=release-ulmo
 ARG OPENEDX_TRANSLATIONS_VERSION=main
 ARG OPENEDX_TRANSLATIONS_REPO=edx/openedx-translations
 


### PR DESCRIPTION
openedx-platform has diverged too much and has updated to Python 3.12, so we need to point this at the edx fork until we are ready to properly upgrade.

https://2u-internal.atlassian.net/browse/BOMS-682