### PR TITLE
fix: Add in expected argument for edxapp builds.

### DIFF
--- a/images-data.json
+++ b/images-data.json
@@ -50,7 +50,8 @@
     "target": "development",
     "build_args": {
       "SERVICE_VARIANT": "cms",
-      "SERVICE_PORT": "18010"
+      "SERVICE_PORT": "18010",
+      "OPENEDX_ATLAS_EXTRA_SOURCES": ""
     }
   },
   {
@@ -61,7 +62,8 @@
     "target": "development",
     "build_args": {
       "SERVICE_VARIANT": "lms",
-      "SERVICE_PORT": "18000"
+      "SERVICE_PORT": "18000",
+      "OPENEDX_ATLAS_EXTRA_SOURCES": ""
     }
   },
   {


### PR DESCRIPTION
edxapp builds require OPENEDX_ATLAS_EXTRA_SOURCES to be set, and the lack of it causes builds to break.

https://2u-internal.atlassian.net/browse/BOMS-682