### PR TITLE
fix: Set default value for OPENEDX_ATLAS_EXTRA_SOURCES.

### DIFF
--- a/dockerfiles/edx-platform.Dockerfile
+++ b/dockerfiles/edx-platform.Dockerfile
@@ -302,7 +302,8 @@ RUN pip install -e .
 # out the stage allows us to shed all of the unwanted out-of-repo changes.
 FROM app-deps AS translations
 
-ARG OPENEDX_ATLAS_EXTRA_SOURCES
+# Set this to the empty string by default.
+ARG OPENEDX_ATLAS_EXTRA_SOURCES=
 ARG OPENEDX_TRANSLATIONS_VERSION
 ARG OPENEDX_TRANSLATIONS_REPO
 


### PR DESCRIPTION
This is required for build, but if it isn't passed in, the build will fail. We'll leave it as an empty string by default.

https://2u-internal.atlassian.net/browse/BOMS-682