### PR TITLE
fix: update syslog format for Datadog parsing

### DIFF
--- a/dockerfiles/edx-platform.Dockerfile
+++ b/dockerfiles/edx-platform.Dockerfile
@@ -289,12 +289,12 @@ try:
     # This should check to see if ddtrace is available in the context for setting up the loggers.
     # If it is available, include Datadog information in the log string. If it is not, exclude it.
     import ddtrace
-    syslog_format = ("[%(name)s] %(levelname)s "
+    syslog_format = ("%(asctime)s %(levelname)s [%(name)s] "
                     "[dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] "
                      "[{hostname}] [process %(process)d] [user %(userid)s] [ip %(remoteip)s] [%(filename)s:%(lineno)d] "
                      "- %(message)s").format(hostname=platform.node().split(".")[0])
 except ImportError:
-    syslog_format = ("[%(name)s] %(levelname)s "
+    syslog_format = ("%(asctime)s %(levelname)s [%(name)s] "
                         "[{hostname}] [process %(process)d] [user %(userid)s] [ip %(remoteip)s] [%(filename)s:%(lineno)d] "
                         "- %(message)s").format(hostname=platform.node().split(".")[0])
 


### PR DESCRIPTION
- Restore timestamp to start of log message to help with parsing and multi-line logs.
- Move log level immediately after timestamp to see if Datadog can better parse the log status.

See https://github.com/openedx/openedx-platform/blob/f46ba85dc19ad280088dc3697e02140a3bc9bc7a/openedx/core/lib/logsettings.py#L191 for original docker-based format.